### PR TITLE
24.1.23.1

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -14,3 +14,4 @@
 ^cran-comments\.md$
 ^README_cache$
 ^CRAN-SUBMISSION$
+^submit_cran\.R$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: simlandr
 Title: Simulation-Based Landscape Construction for Dynamical Systems
-Version: 0.3.0
+Version: 0.3.1
 Authors@R: 
     person("Jingmeng", "Cui", , "jingmeng.cui@outlook.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-3421-8457"))
@@ -41,4 +41,4 @@ Suggests:
     webshot
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.1
+RoxygenNote: 7.3.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# simlandr 0.3.1
+
+- Removed unused parameter `Umax` from the documentation of `make_kernel_dist()` (an internal function).
+
 # simlandr 0.3.0
 
 - Further improved documentation, function, and class names, and cleaned unnecessary exported functions. Removed some deprecated functions.

--- a/R/kernel_api.R
+++ b/R/kernel_api.R
@@ -7,7 +7,6 @@
 #' @param n The number of equally spaced points in each axis, at which the density is to be estimated.
 #' @param h A number, or possibly a vector for 3D and 4D landscapes, specifying the smoothing bandwidth to be used. If missing, the default value of the kernel estimator will be used (but `bw = "SJ"` for `base::density()`). Note that the definition of bandwidth might be different for different kernel estimators. For landscapes based on multiple simulations, the largest `h` of all simulations will be used by default.
 #' @param adjust The multiplier to the bandwidth. The bandwidth used is actually `adjust * h`. This makes it easy to specify values like "half the default" bandwidth.
-#' @param Umax The maximum displayed value of potential.
 #' @return A list of the smooth distribution.
 #' @keywords internal
 make_kernel_dist <- function(output, var_names, lims, kde_fun, n, h, adjust) {

--- a/R/single_simulation_landscape.R
+++ b/R/single_simulation_landscape.R
@@ -1,5 +1,6 @@
 #' Make 2D static landscape plot for a single simulation output
 #' @param x The name of the target variable.
+#' @param Umax The maximum displayed value of potential.
 #' @inheritParams make_kernel_dist
 #' @return A `2d_static_landscape` object that describes the landscape of the system, including the smooth distribution and the landscape plot.
 #' @export
@@ -29,6 +30,7 @@ make_2d_static <- function(output, x, lims, kde_fun = c("ks", "base"), n = 200, 
 #'
 #' @param x,y The names of the target variables.
 #' @inheritParams make_kernel_dist
+#' @inheritParams make_2d_static
 #'
 #' @return A `3d_static_landscape` object that describes the landscape of the system, including the smooth distribution and the landscape plot.
 #'
@@ -62,6 +64,7 @@ make_3d_static <- function(output, x, y, lims, kde_fun = c("ks", "MASS"), n = 20
 #'
 #' @param x,y,z The names of the target variables.
 #' @inheritParams make_kernel_dist
+#' @inheritParams make_2d_static
 #'
 #' @return A `4d_static_landscape` object that describes the landscape of the system, including the smoothed distribution and the landscape plot.
 #'

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,30 +1,30 @@
-- This is a re-submission, in which the size of the package was reduced to meet the CRAN standard.
+## Changes of simlandr 0.3.1
 
-## Changes of simlandr 0.3.0
-
-- Further improved documentations, function and class names, and cleaned unnecessary exported functions. Removed some deprecated functions.
-- Made the parameter names of the landscape functions more consistent; used better default values for landscape functions.
-- For single simulation landscape functions, added `make_*d_single()` alias.
-- Removed some default values for barrier calculation functions (they are often not suitable and can be misleading).
-- Added `print()`, `summary()` and `plot()` methods for several classes.
-- Replaced `get_geom()` with a method of the `autolayer()` generic function from `ggplot2`. `get_geom()` is now deprecated.
-- Replaced `get_barrier_height()` with a method of the `summary()` generic function. `get_barrier_height()` is now deprecated.
-- Renamed `hash_big.matrix` class to `hash_big_matrix` for consistent use of dots; renamed related functions accordingly.
-- Added `coda::cumuplot()` as a possible option for `check_conv()`.
-- For `barrier_batch` objects, renamed the column `b` to `barrier` to avoid possible conflicts.
-- Removed some unnecessary messages.
-- Added some examples to `README`.
-- Updated the vignette: updated some function, object, and parameter names; removed some references that we are now questioning.
-- Bug fix: Parameter `vg` in `make_barrier_grid_2d()` and `make_barrier_grid_3d()` was changed to `ag` and the class of this parameter was changed from `var_grid` (deprecated) to `arg_grid`. 
+- Removed unused parameter `Umax` from the documentation of `make_kernel_dist()` (an internal function). 
 
 ## Test environments
 
-- Github R-CMD-check MacOS R 4.2.2
-- Github R-CMD-check Windows R 4.2.2
-- Github R-CMD-check Ubuntu R-devel
-- Github R-CMD-check Ubuntu R 4.2.2
-- Github R-CMD-check Ubuntu R 4.1.3
+-   local R installation in Windows R 4.3.2
+-   Github R-CMD-check MacOS R 4.3.2
+-   Github R-CMD-check Windows R 4.3.2
+-   Github R-CMD-check Ubuntu R 4.3.2
+-   Github R-CMD-check Ubuntu R-devel
+-   Github R-CMD-check Ubuntu R 4.2.3
 
 ## R CMD check results
 
-0 errors | 0 warnings | 0 note
+0 errors | 0 warnings | 1 note
+
+Maintainer: 'Jingmeng Cui <jingmeng.cui@outlook.com>'
+  
+  Found the following (possibly) invalid URLs:
+    URL: https://psyarxiv.com/pzva3/ (moved to https://osf.io/preprints/psyarxiv/pzva3/)
+      From: README.md
+      Status: 200
+      Message: OK
+    URL: https://www.doi.org/10.1073/pnas.0800579105
+      From: README.md
+      Status: 403
+      Message: Forbidden
+      
+I have checked the URLs and they are all valid. Those notes may come from the delayed response of the servers, or maybe they are not accessible from the checking server.

--- a/man/make_kernel_dist.Rd
+++ b/man/make_kernel_dist.Rd
@@ -20,8 +20,6 @@ make_kernel_dist(output, var_names, lims, kde_fun, n, h, adjust)
 \item{h}{A number, or possibly a vector for 3D and 4D landscapes, specifying the smoothing bandwidth to be used. If missing, the default value of the kernel estimator will be used (but \code{bw = "SJ"} for \code{base::density()}). Note that the definition of bandwidth might be different for different kernel estimators. For landscapes based on multiple simulations, the largest \code{h} of all simulations will be used by default.}
 
 \item{adjust}{The multiplier to the bandwidth. The bandwidth used is actually \code{adjust * h}. This makes it easy to specify values like "half the default" bandwidth.}
-
-\item{Umax}{The maximum displayed value of potential.}
 }
 \value{
 A list of the smooth distribution.

--- a/submit_cran.R
+++ b/submit_cran.R
@@ -1,0 +1,10 @@
+# those commands are used to check the package and to submit it to CRAN
+# a special argument is used to compact the vignettes
+
+devtools::submit_cran(args = c('--compact-vignettes=both'))
+devtools::check_win_devel(args = c('--compact-vignettes=both'))
+devtools::check_win_release(args = c('--compact-vignettes=both'))
+devtools::check_mac_release(args = c('--compact-vignettes=both'))
+devtools::check_rhub(build_args = c('--compact-vignettes=both'))
+devtools::build(args = c('--compact-vignettes=both'))
+devtools::check(remote = TRUE, build_args = c('--compact-vignettes=both'))


### PR DESCRIPTION
Removed unused parameter `Umax` from the documentation of `make_kernel_dist()` (an internal function). Towards v0.3.1.